### PR TITLE
<drop> re-hardcode our bot name in the matchers

### DIFF
--- a/mungegithub/mungers/matchers/comment/interactions.go
+++ b/mungegithub/mungers/matchers/comment/interactions.go
@@ -64,7 +64,7 @@ func (c *CommandArguments) Match(comment *Comment) bool {
 
 // MungeBotAuthor creates a matcher to find mungebot comments
 func MungeBotAuthor() Matcher {
-	return AuthorLogin("k8s-merge-robot")
+	return AuthorLogin("openshift-merge-robot")
 }
 
 // JenkinsBotAuthor creates a matcher to find jenkins bot comments

--- a/mungegithub/mungers/matchers/event/event.go
+++ b/mungegithub/mungers/matchers/event/event.go
@@ -107,7 +107,7 @@ func (c CreatedBefore) Match(event *github.IssueEvent) bool {
 
 // MungeBotActor returns a matcher that checks if the event was completed by MungeBot
 func MungeBotActor() Matcher {
-	return Actor("k8s-merge-robot")
+	return Actor("openshift-merge-robot")
 }
 
 // JenkinsBotActor returns a matcher that checks if the event was completed by JenkinsBot

--- a/mungegithub/mungers/matchers/interactions.go
+++ b/mungegithub/mungers/matchers/interactions.go
@@ -93,7 +93,7 @@ func (*CommandArguments) MatchReviewComment(review *github.PullRequestComment) b
 
 // MungeBotAuthor creates a matcher to find mungebot comments
 func MungeBotAuthor() Matcher {
-	return AuthorLogin("k8s-merge-robot")
+	return AuthorLogin("openshift-merge-robot")
 }
 
 // JenkinsBotAuthor creates a matcher to find jenkins bot comments


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

@kargakis we did not verify the upstream patch fixed _all_ of the hard-coded updates I did ... this is the rest of them