### PR TITLE
Allow Gubernator to read jUnit from all XML in a bucket

### DIFF
--- a/gubernator-rh/view_base.py
+++ b/gubernator-rh/view_base.py
@@ -120,6 +120,12 @@ def gcs_ls(path):
         path += '/'
     return list(gcs.listbucket(path, delimiter='/'))
 
+@memcache_memoize('gs-ls-recursive://', expires=60)
+def gcs_ls_recursive(path):
+    """Enumerate files in a GCS directory recursively. Returns a list of FileStats."""
+    if path[-1] != '/':
+        path += '/'
+    return list(gcs.listbucket(path))
 
 def pad_numbers(s):
     """Modify a string to make its numbers suitable for natural sorting."""

--- a/gubernator-rh/view_build.py
+++ b/gubernator-rh/view_build.py
@@ -71,8 +71,9 @@ class JUnitParser(object):
             try:
                 tree = ET.fromstring(re.sub(r'[\x00\x80-\xFF]+', '?', xml))
             except ET.ParseError, e:
-                self.failed.append(
-                    ('Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename, ''))
+                if re.match(r'junit.*\.xml', os.path.basename(filename)):
+                    self.failed.append(
+                        ('Gubernator Internal Fatal XML Parse Error', 0.0, str(e), filename, ''))
                 return
         if tree.tag == 'testsuite':
             self.handle_suite(tree, filename)
@@ -138,8 +139,8 @@ def build_details(build_dir):
     started = json.loads(started)
     finished = json.loads(finished)
 
-    junit_paths = [f.filename for f in view_base.gcs_ls('%s/artifacts' % build_dir)
-                   if re.match(r'junit_.*\.xml', os.path.basename(f.filename))]
+    junit_paths = [f.filename for f in view_base.gcs_ls_recursive('%s/artifacts' % build_dir)
+                   if re.match(r'.*\.xml', os.path.basename(f.filename))]
 
     junit_futures = {f: gcs_async.read(f) for f in junit_paths}
 


### PR DESCRIPTION
One of the most onerous requirements for the GCS layout is that all
jUnit need to be in a certain place and fit a certain file name format.
This patch removes that requirement and will show jUnit output from all
jUnit XML in the test bucket.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @csrwng