### PR TITLE
jenkins-config-updater: remove redundant loggers

### DIFF
--- a/experiment/jenkins-config-updater/main.go
+++ b/experiment/jenkins-config-updater/main.go
@@ -77,12 +77,6 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting git client.")
 	}
 
-	logger := logrus.StandardLogger()
-	// TODO: Use global option from the prow config.
-	logrus.SetLevel(logrus.DebugLevel)
-	githubClient.Logger = logger.WithField("client", "github")
-	gitClient.Logger = logger.WithField("client", "git")
-
 	botName, err := githubClient.BotName()
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting bot name.")


### PR DESCRIPTION
Other commits updated git and github clients to default to the desired
logger settings.