### PR TITLE
Externalize action config for the update plugin

### DIFF
--- a/experiment/jenkins-config-updater/server.go
+++ b/experiment/jenkins-config-updater/server.go
@@ -19,6 +19,7 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -31,6 +32,7 @@ import (
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/plugins"
 )
 
 const pluginName = "jenkins-config-updater"
@@ -45,6 +47,21 @@ type githubClient interface {
 	CreateFork(org, repo string) error
 }
 
+type ActionConfig struct {
+	Actions []Action `json:"actions"`
+}
+
+type Action struct {
+	Prefix     string `json:"prefix"`
+	MakeTarget string `json:"action"`
+}
+
+type result struct {
+	action Action
+	output string
+	err    error
+}
+
 // Server implements http.Handler. It validates incoming GitHub webhooks and
 // then dispatches them to the appropriate plugins.
 type Server struct {
@@ -56,11 +73,11 @@ type Server struct {
 	ghc githubClient
 	log *logrus.Entry
 
-	repos []github.Repo
+	actionConfig ActionConfig
 }
 
 // NewServer returns new server
-func NewServer(name, creds string, hmac []byte, gc *git.Client, ghc *github.Client, repos []github.Repo) *Server {
+func NewServer(name, creds string, hmac []byte, gc *git.Client, ghc *github.Client, config ActionConfig) *Server {
 	return &Server{
 		hmacSecret:  hmac,
 		credentials: creds,
@@ -70,7 +87,7 @@ func NewServer(name, creds string, hmac []byte, gc *git.Client, ghc *github.Clie
 		ghc: ghc,
 		log: logrus.StandardLogger().WithField("client", "jenkins-config-updater"),
 
-		repos: repos,
+		actionConfig: config,
 	}
 }
 
@@ -83,12 +100,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Event received. Have a nice day.")
 
 	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
-		logrus.WithError(err).Error("Error parsing event.")
+		logrus.WithError(err).Error("Error handling event.")
 	}
 }
 
 func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
-	s.log.Debug("received webhook")
+	s.log.WithField("eventType", eventType).WithField("eventGUID", eventGUID).Info("Received webhook")
 	if eventType != "pull_request" {
 		return fmt.Errorf("received an event of type %q but didn't ask for it", eventType)
 	}
@@ -97,6 +114,13 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 	if err := json.Unmarshal(payload, &pre); err != nil {
 		return err
 	}
+	s.log = s.log.WithFields(map[string]interface{}{
+		"org":    pre.Repo.Owner.Login,
+		"repo":   pre.Repo.Name,
+		"pr":     pre.Number,
+		"author": pre.PullRequest.User.Login,
+		"url":    pre.PullRequest.HTMLURL,
+	})
 
 	if pre.Action != github.PullRequestActionClosed {
 		return nil
@@ -114,22 +138,6 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 	changes, err := s.ghc.GetPullRequestChanges(org, repo, num)
 	if err != nil {
 		s.log.Info("error getting pull request changes")
-		return nil
-	}
-
-	found := false
-	for _, change := range changes {
-		s.log.Debug("considering change to file: " + change.Filename)
-		if strings.HasPrefix(change.Filename, "cluster/ci/origin/jjb/") {
-			s.log.Debug("file looks applicable")
-			found = true
-			break
-		} else {
-			s.log.Debug("file does not look applicable")
-		}
-	}
-	if !found {
-		s.log.Debug("did not find applicable changed file")
 		return nil
 	}
 
@@ -152,17 +160,87 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 	}
 	s.log.WithField("duration", time.Since(startClone)).Info("Cloned and checked out target branch.")
 
-	startMake := time.Now()
+	completedTasks := []result{}
+	failedTasks := []result{}
+	for _, action := range s.actionConfig.Actions {
+		logger := s.log.WithField("target", action.MakeTarget)
+		found := false
+		for _, change := range changes {
+			logger.Debug("considering change to file: " + change.Filename)
+			if strings.HasPrefix(change.Filename, action.Prefix) {
+				logger.Debug("file looks applicable")
+				found = true
+				break
+			} else {
+				logger.Debug("file does not look applicable")
+			}
+		}
+		if !found {
+			logger.Debug("did not find applicable changed file")
+			return nil
+		}
 
-	cmd := exec.Command("/bin/bash", r.Dir+"/cluster/ci/origin/jjb/make.sh")
-	s.log.Info("Running: /bin/bash " + r.Dir + "/cluster/ci/origin/jjb/make.sh")
-	out, err := cmd.CombinedOutput()
-	s.log.Info("output: " + string(out[:]))
+		logger.Info("Running action")
+		startAction := time.Now()
+		cmd := exec.Command("/usr/bin/make", action.MakeTarget)
+		cmd.Dir = r.Dir
+		out, err := cmd.CombinedOutput()
+		logger.Info("output: " + string(out[:]))
+		logger.WithField("duration", time.Since(startAction)).Info("Ran action")
+		taskResult := result{action, string(out), err}
 
-	if err != nil {
-		return err
+		if err != nil {
+			failedTasks = append(failedTasks, taskResult)
+		} else {
+			completedTasks = append(completedTasks, taskResult)
+		}
 	}
-	s.log.WithField("duration", time.Since(startMake)).Info("Ran make.sh")
 
-	return nil
+	if len(completedTasks) == 0 && len(failedTasks) == 0 {
+		return nil
+	}
+
+	var commentBuffer bytes.Buffer
+	if len(completedTasks) > 0 {
+		commentBuffer.WriteString("The following updates succeeded:\n")
+		commentBuffer.WriteString("<ul>\n")
+		for _, task := range completedTasks {
+			commentBuffer.WriteString(formatDetails(task))
+		}
+		commentBuffer.WriteString("</ul>\n")
+	}
+
+	if len(failedTasks) > 0 {
+		commentBuffer.WriteString("The following updates failed:\n")
+		commentBuffer.WriteString("<ul>\n")
+		for _, task := range failedTasks {
+			commentBuffer.WriteString(formatDetails(task))
+		}
+		commentBuffer.WriteString("</ul>\n")
+	}
+
+	return s.ghc.CreateComment(
+		org, repo, num,
+		plugins.FormatResponseRaw(
+			pre.PullRequest.Body,
+			pre.PullRequest.HTMLURL,
+			pre.PullRequest.User.Login,
+			commentBuffer.String(),
+		),
+	)
+}
+
+func formatDetails(taskResult result) string {
+	return fmt.Sprintf(`  <li>
+    <details>
+    <summary><code>make %s</code><summary>
+
+    <pre><code>
+    $ make %s
+    %s
+    %v
+    </pre></code>
+
+    </details>
+  </li>`, taskResult.action.MakeTarget, taskResult.action.MakeTarget, taskResult.output, taskResult.err)
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @kargakis @csrwng @paradigm

Externalize the prefix --> action. Normalize it to `make` target. Add response comment.