### PR TITLE
WIP: experimental support for vendor <-> fork repo synchronization

### DIFF
--- a/experiment/BUILD
+++ b/experiment/BUILD
@@ -30,6 +30,7 @@ filegroup(
         "//experiment/commenter:all-srcs",
         "//experiment/manual-trigger:all-srcs",
         "//experiment/refresh:all-srcs",
+        "//experiment/vendor-syncer:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/experiment/vendor-syncer/BUILD
+++ b/experiment/vendor-syncer/BUILD
@@ -1,0 +1,48 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "main.go",
+        "server.go",
+    ],
+    importpath = "k8s.io/test-infra/experiment/vendor-syncer",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/git:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/hook:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "vendor-syncer",
+    importpath = "k8s.io/test-infra/experiment/vendor-syncer",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    importpath = "k8s.io/test-infra/experiment/vendor-syncer",
+    library = ":go_default_library",
+    deps = ["//prow/github:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/experiment/vendor-syncer/Dockerfile
+++ b/experiment/vendor-syncer/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-prow/git:0.1
+MAINTAINER mfojtik@redhat.com
+
+COPY vendor-syncer /vendor-syncer
+ENTRYPOINT ["/vendor-syncer"]

--- a/experiment/vendor-syncer/OWNERS
+++ b/experiment/vendor-syncer/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- mfojtik
+- kargakis
+- stevekuznetsov

--- a/experiment/vendor-syncer/doc.go
+++ b/experiment/vendor-syncer/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TBD
+//
+// Required scopes: read:org, repo
+package main

--- a/experiment/vendor-syncer/main.go
+++ b/experiment/vendor-syncer/main.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+)
+
+var (
+	port              = flag.Int("port", 8888, "Port to listen on.")
+	dryRun            = flag.Bool("dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	githubEndpoint    = flag.String("github-endpoint", "https://api.github.com", "GitHub's API endpoint.")
+	githubTokenFile   = flag.String("github-token-file", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	webhookSecretFile = flag.String("hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	forksMappingsFile = flag.String("forks-mappings-file", "", "Path to the file containing mappings between vendor and fork repositories.")
+)
+
+func main() {
+	flag.Parse()
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// Ignore SIGTERM so that we don't drop hooks when the pod is removed.
+	// We'll get SIGTERM first and then SIGKILL after our graceful termination
+	// deadline.
+	signal.Ignore(syscall.SIGTERM)
+
+	webhookSecretRaw, err := ioutil.ReadFile(*webhookSecretFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read webhook secret file.")
+	}
+	webhookSecret := bytes.TrimSpace(webhookSecretRaw)
+
+	oauthSecretRaw, err := ioutil.ReadFile(*githubTokenFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read oauth secret file.")
+	}
+	oauthSecret := string(bytes.TrimSpace(oauthSecretRaw))
+
+	_, err = url.Parse(*githubEndpoint)
+	if err != nil {
+		logrus.WithError(err).Fatal("Must specify a valid --github-endpoint URL.")
+	}
+
+	githubClient := github.NewClient(oauthSecret, *githubEndpoint)
+	if *dryRun {
+		githubClient = github.NewDryRunClient(oauthSecret, *githubEndpoint)
+	}
+
+	gitClient, err := git.NewClient()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting git client.")
+	}
+
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.DebugLevel)
+
+	// The bot name is used to determine to what fork we can push cherry-pick branches.
+	botName, err := githubClient.BotName()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot name.")
+	}
+
+	gitClient.SetCredentials(botName, oauthSecret)
+
+	repos, err := githubClient.GetRepos(botName, true)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error listing bot repositories.")
+	}
+
+	// TODO: Make fork mappings hot-reloadable
+	server := NewServer(botName, oauthSecret, webhookSecret, gitClient, githubClient, repos, *forksMappingsFile)
+
+	http.Handle("/", server)
+	logrus.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}

--- a/experiment/vendor-syncer/sample_config.yaml
+++ b/experiment/vendor-syncer/sample_config.yaml
@@ -1,0 +1,11 @@
+---
+repositories:
+  # This key gets matched with 'UPSTREAM: containers/image: ...' message.
+  "containers/image":
+    # forkRepository represents the location of fork repository
+    forkRepository: github.com/foo/containers-image
+    # forkDefaultBranch represents the branch name where we will apply patches
+    forkDefaultBranch: release-1.0
+    # vendorPath is used for patch generation and applying where we need to
+    # strip this path.
+    vendorPath: vendor/github.com/containers/image

--- a/experiment/vendor-syncer/server.go
+++ b/experiment/vendor-syncer/server.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/hook"
+)
+
+const pluginName = "vendor-sync"
+
+// VendorForkMappings maps the vendor repositories to their forks.
+type VendorForkMappings struct {
+	// The key in this mapping is the short name of the repository
+	// used in the commit message, eg. "UPSTREAM: containers/image: 00000: description"
+	Repositories map[string]ForkMapping `yaml:"repositories"`
+}
+
+// ForkMapping represents a full fork repository name and the source repository
+// vendor path where the patches were applied.
+// The VendorPath is required so we know how to apply the patch file (how many
+// slashes are going to be stripped).
+type ForkMapping struct {
+	// ForkRepository represents a real location of the fork repository for this vendor
+	ForkRepository string `yaml:"forkRepository"`
+	// ForkDefaultBranch is the default branch we open a PRs against
+	// TODO: We should try to figure this out from the glide.yaml
+	ForkDefaultBranch string `yaml:"forkDefaultBranch"`
+	// VendorPath is the location where this fork is vendored inside source
+	// repository.
+	VendorPath string `yaml:"vendorPath"`
+}
+
+type githubClient interface {
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	CreateComment(org, repo string, number int, comment string) error
+	IsMember(org, user string) (bool, error)
+	CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error)
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	CreateFork(org, repo string) error
+}
+
+// Server implements http.Handler. It validates incoming GitHub webhooks and
+// then dispatches them to the appropriate plugins.
+type Server struct {
+	hmacSecret []byte
+	botName    string
+
+	gc  *git.Client
+	ghc githubClient
+	log *logrus.Entry
+
+	bare     *http.Client
+	patchURL string
+
+	repoLock sync.Mutex
+	repos    []github.Repo
+
+	forksMappingsConfig VendorForkMappings
+}
+
+func NewServer(name, creds string, hmac []byte, gc *git.Client, ghc *github.Client, repos []github.Repo, forkMappingsFile string) *Server {
+	if len(forkMappingsFile) == 0 {
+		logrus.Error("Fork mappings config file must be specified")
+	}
+	forkMappings, err := readForkMappingsConfig(forkMappingsFile)
+	if err != nil {
+		logrus.WithError(err).Errorf("Error parsing fork mappings config file %q", forkMappingsFile)
+		return nil
+	}
+	return &Server{
+		hmacSecret: hmac,
+		botName:    name,
+
+		gc:  gc,
+		ghc: ghc,
+		log: logrus.StandardLogger().WithField("client", "vendor-sync"),
+
+		bare:     &http.Client{},
+		patchURL: "https://patch-diff.githubusercontent.com",
+
+		repos:               repos,
+		forksMappingsConfig: *forkMappings,
+	}
+}
+
+func readForkMappingsConfig(name string) (*VendorForkMappings, error) {
+	yamlFile, err := ioutil.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	var result VendorForkMappings
+	if err := yaml.Unmarshal(yamlFile, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ServeHTTP validates an incoming webhook and puts it into the event channel.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	eventType, eventGUID, payload, ok := hook.ValidateWebhook(w, r, s.hmacSecret)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	switch eventType {
+	case "push":
+		var push github.PushEvent
+		if err := json.Unmarshal(payload, &push); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handlePush(push, s.forksMappingsConfig); err != nil {
+				s.log.WithError(err).Info("Vendor sync failed.")
+			}
+		}()
+	default:
+		return fmt.Errorf("received an event of type %q but didn't ask for it", eventType)
+	}
+	return nil
+}
+
+// PickCommit is variant of commit where we changing one or more files but
+// not bumping the dependency level. Usually we pick a commit that has
+// upstream alternative. These commits start with "UPSTREAM: " prefix.
+type PickCommit struct {
+	// ID represents a SHA256 of the commit that is going to be picked
+	ID string
+
+	// SourceRepository represents a repository from where the commit will be
+	// extracted.
+	SourceRepository string
+
+	// Mapping contains information about target (fork) repository and the
+	// mapping to the filesystem path in vendor/ directory.
+	Mapping *ForkMapping
+
+	// Author represents the author of the commit.
+	Author string
+
+	// For PR body
+	Message string
+}
+
+// PullRequestDetails contains additional information about pull requests.
+type PullRequestDetails struct {
+	Author string
+}
+
+// ForkRepository returns the repository this pick was made for.
+func (c *PickCommit) ForkRepository() string {
+	if c.Mapping == nil {
+		return ""
+	}
+	return c.Mapping.ForkRepository
+}
+
+// WithBranch returns fork repository and the default branch for the given fork
+// repository.
+// TODO: We should be able to determine the branch from the commit?
+func (c *PickCommit) WithBranch() string {
+	return c.ForkRepository() + "#" + c.Mapping.ForkDefaultBranch
+}
+
+func processCommit(c github.Commit, forks VendorForkMappings) *PickCommit {
+	var result *PickCommit
+	if strings.HasPrefix(strings.TrimSpace(c.Message), "UPSTREAM: ") {
+		message := strings.TrimSpace(c.Message)
+		if pos := strings.Index(message[10:], ": "); pos != -1 {
+			mappings := getForkMapping(message[10:10+pos], forks)
+			result = &PickCommit{
+				ID:      c.ID,
+				Mapping: mappings,
+				Message: strings.TrimSpace(c.Message),
+			}
+		}
+	}
+	// TODO: Do we need to handle <drop> commits?
+	return result
+}
+
+func getForkMapping(shortRepository string, forks VendorForkMappings) *ForkMapping {
+	// try to find an exact match first
+	mapping, ok := forks.Repositories[shortRepository]
+	if ok {
+		return &mapping
+	}
+	// no match, guess the last two segments is the shortName
+	parts := strings.Split(shortRepository, "/")
+	if len(parts) < 2 {
+		return nil
+	}
+	mapping, ok = forks.Repositories[strings.Join(parts[len(parts)-2:], "/")]
+	if ok {
+		return &mapping
+	}
+	return nil
+}
+
+func (s *Server) handlePush(p github.PushEvent, forks VendorForkMappings) error {
+	// Fill the information about commits and group them based on the targed
+	// repository.
+	commits := map[string][]*PickCommit{}
+	for _, commit := range p.Commits {
+		// check if the commit is changing vendor/ (iow. has UPSTREAM: prefix)
+		// extract information about this commit and get fork repo mappings.
+		c := processCommit(commit, forks)
+		if c == nil {
+			// commit is not UPSTREAM commit
+			continue
+		}
+		// TODO: Need to handle the case when there is no fork-mapping defined for
+		// the commit. Probably need to inform the commit author about doing the
+		// pick manually after the fork repo is created.
+		if len(c.ForkRepository()) == 0 {
+			s.log.Infof("No fork repository mapping defined for: %s", c.Message)
+			continue
+		}
+		// fill more details from the hook payload
+		c.SourceRepository = p.Repo.HTMLURL
+		c.Author = p.Sender.Login
+		commits[c.WithBranch()] = append(commits[c.WithBranch()], c)
+	}
+
+	// Open PR's with grouped commits
+	for forkRepo, groupedCommits := range commits {
+		// ID is needed for uniqe working branch name
+		shortID := string(groupedCommits[0].ID[0:7])
+		go s.handlePicksForRepo(shortID, forkRepo, groupedCommits)
+	}
+	return nil
+}
+
+func (s *Server) handlePicksForRepo(ref string, forkRepoBranch string, picks []*PickCommit) {
+	parts := strings.Split(forkRepoBranch, "#")
+	forkRepo := parts[0]
+	forkBranch := parts[1]
+
+	s.log.Debugf("Cloning %s", forkRepo)
+	targetRepo, err := s.gc.Clone(forkRepo)
+	if err != nil {
+		s.log.WithError(err).Error("Error cloning fork repository.")
+		return
+	}
+	defer targetRepo.Clean()
+
+	if err := targetRepo.Config("user.name", "vendorpicker"); err != nil {
+		s.log.WithError(err).Errorf("Error setting user.name")
+		return
+	}
+	if err := targetRepo.Config("user.email", "vendorpicker@localhost"); err != nil {
+		s.log.WithError(err).Errorf("Error setting user.email")
+		return
+	}
+
+	s.log.Debugf("Checkouting target branch %s", forkBranch)
+	if err := targetRepo.Checkout(forkBranch); err != nil {
+		s.log.WithError(err).Errorf("Error checking out target branch %s.", forkBranch)
+		return
+	}
+	workingBranch := "auto-pick-" + forkBranch + "-" + ref
+	s.log.Debugf("Creating working branch %s", workingBranch)
+	if err := targetRepo.CheckoutNewBranch(workingBranch); err != nil {
+		s.log.WithError(err).Errorf("Error checking out branch %s.", workingBranch)
+		return
+	}
+
+	messages := []string{}
+	authors := []string{}
+	sourceRepo := ""
+	for _, commit := range picks {
+		s.log.Debugf("Fetching commit %#v", commit)
+		patchFile, err := s.getPatchFile(commit.SourceRepository, commit.ID)
+		if err != nil {
+			s.log.WithError(err).Errorf("Error getting patch for commit %q.", commit.ID)
+			return
+		}
+
+		// apply the patch in the destination repository
+		// git am -3 -p<slashes> /tmp/patch
+		s.log.Debugf("Applying %s in %q", commit.Message, forkRepo)
+		if err := s.applyPatch(commit, targetRepo.Dir, patchFile); err != nil {
+			// TODO: Probably need to notify the authors that their commits have not
+			// applied cleanely.
+			s.log.WithError(err).Errorf("Error applying patch for %q.", commit.ID)
+			return
+		}
+		messages = append(messages, commit.Message)
+		authors = append(authors, commit.Author)
+		sourceRepo = commit.SourceRepository
+	}
+
+	// TODO: Need to figure out good PR title here. If there is more than one
+	//       commit, this might get pretty long, so shorted in that case.
+	title := "Automatic pick for " + ref
+	if len(messages) == 1 {
+		title = "Automatic pick of " + messages[0]
+	}
+	body := fmt.Sprintf("This is automatic pick from %s.\n", sourceRepo)
+	for _, author := range authors {
+		body += "/cc @" + author
+	}
+	head := fmt.Sprintf("%s:%s", s.botName, workingBranch)
+	repoParts := strings.Split(forkRepo, "/")
+
+	s.log.Debugf("Pushing branch %s to %s", workingBranch, forkRepoBranch)
+	if err := targetRepo.Push(repoParts[1], workingBranch); err != nil {
+		s.log.WithError(err).Errorf("Error pushing working branch")
+		return
+	}
+
+	// TODO: We should probably just push to fork instead of creating a PR there?
+	_, err = s.ghc.CreatePullRequest(repoParts[0], repoParts[1], title, body, head, forkBranch, true)
+	if err != nil {
+		s.log.WithError(err).Errorf("Error opening pull request")
+		return
+	}
+}
+
+func (s *Server) getPatchFile(sourceRepo, commitID string) (string, error) {
+	url := fmt.Sprintf("%s/commit/%s.patch", sourceRepo, commitID)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	// TODO: Add retries
+	resp, err := s.bare.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("cannot get Github patch for commit %s: %s", commitID, resp.Status)
+	}
+	outputDir, err := ioutil.TempDir("", "vendor-sync")
+	if err != nil {
+		return "", err
+	}
+	outputFile := path.Join(outputDir, fmt.Sprintf("%s.patch", commitID))
+	out, err := os.Create(outputFile)
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return "", err
+	}
+	return outputFile, nil
+}
+
+func (s *Server) applyPatch(c *PickCommit, baseRepoDir string, patchFile string) error {
+	stripSlashesCount := fmt.Sprintf("-p%d", strings.Count(c.Mapping.VendorPath, "/")+2)
+	cmd := exec.Command("git", "am", "-3", "--ignore-whitespace", stripSlashesCount, patchFile)
+	cmd.Dir = baseRepoDir
+	output, err := cmd.CombinedOutput()
+	s.log.Infof("git am: %s", output)
+	return err
+}

--- a/experiment/vendor-syncer/server_test.go
+++ b/experiment/vendor-syncer/server_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/test-infra/prow/github"
+)
+
+func TestGetRepositoryFromMessage(t *testing.T) {
+	testMapping := ForkMapping{
+		ForkRepository:    "github.com/forkorg/containers-image",
+		ForkDefaultBranch: "release-1.0",
+		VendorPath:        "vendor/github.com/containers/image",
+	}
+	testMappingConfig := VendorForkMappings{
+		Repositories: map[string]ForkMapping{
+			"containers/image": testMapping,
+		},
+	}
+
+	table := []struct {
+		commit github.Commit
+		expect *PickCommit
+	}{
+		{
+			commit: github.Commit{
+				ID:      "c4eefeff07841366bbca7c86e71929a3c5bf2d04",
+				Message: "UPSTREAM: containers/image: 2384: Some commit message",
+			},
+			expect: &PickCommit{
+				ID:      "c4eefeff07841366bbca7c86e71929a3c5bf2d04",
+				Message: "UPSTREAM: containers/image: 2384: Some commit message",
+				Mapping: &testMapping,
+			},
+		},
+	}
+
+	for _, tc := range table {
+		got := processCommit(tc.commit, testMappingConfig)
+		if !reflect.DeepEqual(got, tc.expect) {
+			t.Errorf("[%s] expected:\n\t %#+v\n got:\n\t %#+v", tc.commit, tc.expect, got)
+		}
+		if got == nil {
+			continue
+		}
+	}
+}
+
+func TestReadForkMappingsFile(t *testing.T) {
+	mappings, err := readForkMappingsConfig("sample_config.yaml")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(mappings.Repositories) == 0 {
+		t.Error("expected non-empty repositories")
+	}
+	if mappings.Repositories["containers/image"].ForkRepository != "github.com/foo/containers-image" {
+		t.Errorf("invalid forkRepository for containers/image: %q", mappings.Repositories["containers/image"].ForkRepository)
+	}
+}
+
+func TestGetForkMapping(t *testing.T) {
+	table := []struct {
+		shortRepo       string
+		config          VendorForkMappings
+		expectedMapping *ForkMapping
+	}{
+		{
+			shortRepo: "containers/image",
+			config: VendorForkMappings{Repositories: map[string]ForkMapping{
+				"containers/image": {},
+			}},
+			expectedMapping: &ForkMapping{},
+		},
+		{
+			shortRepo: "unknown/repo",
+			config: VendorForkMappings{Repositories: map[string]ForkMapping{
+				"containers/image": {},
+			}},
+			expectedMapping: nil,
+		},
+		{
+			shortRepo: "github.com/containers/image",
+			config: VendorForkMappings{Repositories: map[string]ForkMapping{
+				"containers/image": {},
+			}},
+			expectedMapping: &ForkMapping{},
+		},
+		{
+			shortRepo: "",
+			config: VendorForkMappings{Repositories: map[string]ForkMapping{
+				"k8s.io/kubernetes": {},
+			}},
+			expectedMapping: nil,
+		},
+	}
+
+	for _, tc := range table {
+		got := getForkMapping(tc.shortRepo, tc.config)
+		if !reflect.DeepEqual(got, tc.expectedMapping) {
+			t.Errorf("[%s] expected %#v mapping, got %#v", tc.shortRepo, tc.expectedMapping, *got)
+		}
+	}
+}


### PR DESCRIPTION
This plugin does the synchronization between the source repository (origin in our case) and the "fork" repository "github.com/openshift/containers-image" for example.

The workflow is:

1) You open a PR against origin that makes changes inside `vendor/github.com/container/image`.
2) The PR include commit: `UPSTREAM: containers/image: 00000: Test`
3) You merge the PR into openshift/origin
4) This plugin should observe that push and automatically create a PR in the github.com/openshif/containers-image repository (now PR vs. direct merge is open for debate).
5) Now both origin and fork has the commits

To make this plugin work, you will need to define the mappings between origin `vendor/` folder and the corresponding fork repository. This could be smarter by reading the glide.yaml or doing some magic guessing, but to start, I think we should have things hardcoded.

The YAML file is part of this PR.

What will happen internally is:

1) We determine if the push events has commits that matches `UPSTREAM: ...` pattern.
2) We determine the vendor<->fork mappings for them
3) If we have mappings defined, we clone the "origin" and "fork" repo (we can skip cloning origin and just fetch the commit patch from GH...)
4) Then we run `format-patch` in origin repo with the corresponding UPSTREAM commit ID
5) We create working branch in "fork" repo
5) We use the `vendorPath` to determine how many slashes we are going to strip and then `git am` the patch into "fork" repo working branch
6) We open a PR for fork repo.

This is trying to replace @deads2k [script](https://github.com/deads2k/sync-vendor)
I built the vendor-syncer Docker image: `docker.io/mfojtik/vendor-syncer:v0.1-alpha`