### PR TITLE
Add a skeleton for job-rehearse tool

### DIFF
--- a/experiment/pj-rehearse/main.go
+++ b/experiment/pj-rehearse/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+func getJobsToExecute() config.JobConfig {
+	return config.JobConfig{
+		Presubmits: map[string][]config.Presubmit{},
+	}
+}
+
+func execute(jobs config.JobConfig) {
+	for repo, jobs := range jobs.Presubmits {
+		fmt.Printf("Jobs for repo: %s:\n", repo)
+		for _, job := range jobs {
+			fmt.Printf("  %s\n", job)
+		}
+	}
+}
+
+func main() {
+	var jobs config.JobConfig
+
+	jobs = getJobsToExecute()
+	execute(jobs)
+}


### PR DESCRIPTION
The tool should discover a set of jobs execute to test a proposed change
to job/test configuration (=to openshift/release repo) and execute it.

The PR only creates a skeleton to be collaborated & iterated on. The name `job-rehearse` is provisional.

/cc @droslean @stevekuznetsov @bbguimaraes 