### PR TITLE
Display full metadata from builds in Gubernator if set

### DIFF
--- a/gubernator-rh/filters.py
+++ b/gubernator-rh/filters.py
@@ -19,6 +19,7 @@ import os
 import re
 import time
 import urllib
+import urlparse
 
 import jinja2
 
@@ -85,6 +86,14 @@ def do_github_commit_link(commit, repo):
     commit_url = jinja2.escape(GITHUB_COMMIT_TEMPLATE % (repo, commit))
     return jinja2.Markup('<a href="%s">%s</a>' % (commit_url, commit[:8]))
 
+def do_maybe_linkify(inp):
+    try:
+        if urlparse.urlparse(inp).scheme in ('http', 'https'):
+            inp = unicode(jinja2.escape(inp))
+            return jinja2.Markup('<a href="%s">%s</a>' % (inp, inp))
+    except (AttributeError, TypeError):
+        pass
+    return inp
 
 def do_testcmd(name):
     if name.startswith('k8s.io/'):

--- a/gubernator-rh/templates/build.html
+++ b/gubernator-rh/templates/build.html
@@ -8,7 +8,7 @@
 % endblock
 % block header
 <div>
-<h1>{% if pr and pr != "batch"  %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes"%}{{repo}} {% endif %}PR #{{pr}}</a> {% endif %}
+<h1>{% if pr and pr != "batch"  %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes"%}{{repo}} {% endif %}PR #{{pr}}</a> (<a href="https://github.com/{{repo}}/pull/{{pr}}">GitHub</a>){% endif %}
 	<span>
 	% if testgrid_query
 		<a href="{{testgrid_query|tg_url}}">{{job}}</a>
@@ -45,7 +45,6 @@
 		% endif
 		<tr><td>Started<td>{{started['timestamp']|timestamp}}
 		{% if finished %}<tr><td>Elapsed<td>{{(finished['timestamp']-started['timestamp'])|duration}}{% endif %}
-		<tr><td>Version<td><a href="https://github.com/{{repo}}/commit/{{commit}}">{{started['version'] or finished['version']}}</a>
 		% if 'jenkins-node' in started
 			<tr><td>Builder<td>{{started['jenkins-node']}}
 		% endif
@@ -60,6 +59,22 @@
 				{%- if sha %}:{{sha|github_commit_link(repo)}}{% endif %}<br>
 			{%- endfor %}
 		% endif
+
+		% if 'metadata' in started
+			% for k, v in started['metadata']|dictsort
+				% if v
+					<tr><td>{{k}}<td>{{v|maybe_linkify}}
+				% endif
+			% endfor
+		% endif
+		% if finished and 'metadata' in finished and finished['metadata']
+			% for k, v in finished['metadata']|dictsort
+				% if v
+					<tr><td>{{k}}<td>{{v|maybe_linkify}}
+				% endif
+			% endfor
+		% endif
+
 	% endif
 	</table>
 	<ul class="nav">

--- a/gubernator-rh/view_build.py
+++ b/gubernator-rh/view_build.py
@@ -261,9 +261,18 @@ class BuildHandler(view_base.BaseHandler):
 
         issues = list(models.GHIssueDigest.find_xrefs(build_dir))
 
-        refs = []
+        # openshift does not have a pull string because the entrypoint does not
+        # set it into started
+        ref_string = ""
         if started and 'pull' in started:
-            for ref in started['pull'].split(','):
+            ref_string = started['pull']
+        if len(ref_string) == 0 and finished and 'metadata' in finished and 'repos' in finished['metadata']:
+            if repo in finished['metadata']['repos']:
+                ref_string = finished['metadata']['repos'][repo]
+
+        refs = []
+        if len(ref_string) > 0:
+            for ref in ref_string.split(','):
                 x = ref.split(':', 1)
                 if len(x) == 2:
                     refs.append((x[0], x[1]))


### PR DESCRIPTION
The newer prow entrypoint path does not set 'pull' on the started.json
and so we must infer it from metadata on finished. Add a link direct
to github. Show all metadata inline if set.