### PR TITLE
Link the work namespace to api.ci and prune it from generic meta

### DIFF
--- a/gubernator-rh/templates/build.html
+++ b/gubernator-rh/templates/build.html
@@ -48,6 +48,9 @@
 		% if 'jenkins-node' in started
 			<tr><td>Builder<td>{{started['jenkins-node']}}
 		% endif
+		% if work_namespace
+			<tr><td>Work namespace<td><a href="https://api.ci.openshift.org/console/project/{{work_namespace}}/browse/pods">{{work_namespace}}</a>
+		% endif
 		% if refs
 			<tr><td>Refs<td>
 			% for name, sha in refs

--- a/gubernator-rh/view_build.py
+++ b/gubernator-rh/view_build.py
@@ -269,6 +269,7 @@ class BuildHandler(view_base.BaseHandler):
         if len(ref_string) == 0 and finished and 'metadata' in finished and 'repos' in finished['metadata']:
             if repo in finished['metadata']['repos']:
                 ref_string = finished['metadata']['repos'][repo]
+                del finished['metadata']['repos'][repo]
 
         refs = []
         if len(ref_string) > 0:
@@ -279,10 +280,16 @@ class BuildHandler(view_base.BaseHandler):
                 else:
                     refs.append((x[1], ''))
 
+        work_namespace = ""
+        if finished and 'metadata' in finished and finished['metadata'] and 'work-namespace' in finished['metadata']:
+            work_namespace = finished['metadata']['work-namespace']
+            del finished['metadata']['work-namespace']
+
         self.render('build.html', dict(
             job_dir=job_dir, build_dir=build_dir, job=job, build=build,
             commit=commit, started=started, finished=finished,
             res=results, refs=refs,
+            work_namespace=work_namespace,
             build_log=build_log, build_log_src=build_log_src,
             issues=issues, repo=repo,
             pr_path=pr_path, pr=pr, pr_digest=pr_digest,


### PR DESCRIPTION
PR authors can now jump directly to the console if they have access.

Staging: https://20190107t005232-dot-openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/21735/pull-ci-openshift-origin-master-e2e-aws/1888